### PR TITLE
Fix bug with Theme Editor part 2

### DIFF
--- a/upload/catalog/controller/event/theme.php
+++ b/upload/catalog/controller/event/theme.php
@@ -40,7 +40,11 @@ class ControllerEventTheme extends Controller {
 		$theme_info = $this->model_design_theme->getTheme($route, $theme);
 		
 		if ($theme_info) {
+			// Fix Theme Editor
+			if (!is_file(DIR_MODIFICATION . basename(DIR_APPLICATION) . '/' . substr(DIR_TEMPLATE, strlen(DIR_APPLICATION)) . $theme . '/template/' . $route . '.twig')) {
 			$template = html_entity_decode($theme_info['code'], ENT_QUOTES, 'UTF-8');
+			}
+			// Fix Theme Editor
 		} elseif (is_file(DIR_TEMPLATE . $theme . '/template/' . $route . '.twig')) {
 			$this->config->set('template_directory', $theme . '/template/');
 		} elseif (is_file(DIR_TEMPLATE . 'default/template/' . $route . '.twig')) {


### PR DESCRIPTION
When using the theme editor, OCMOD cache files are not considered and not checked.
And if the file changes both in the Theme Editor and through modifiers, changes from OCMOD are ignored.

This patch fixes it (part 2)