### PR TITLE
Удаление лога при обновлении модификаторов

### DIFF
--- a/upload/admin/controller/marketplace/modification.php
+++ b/upload/admin/controller/marketplace/modification.php
@@ -65,6 +65,10 @@ class ControllerMarketplaceModification extends Controller {
 			$this->load->model('setting/setting');
 
 			$this->model_setting_setting->editSettingValue('config', 'config_maintenance', true);
+			
+			if (file_exists(DIR_LOGS . 'ocmod.log')) {
+				unlink(DIR_LOGS . 'ocmod.log');
+			}
 
 			//Log
 			$log = array();


### PR DESCRIPTION
Иначе при работе накапливается такой размер лога, что раздел модификаторов, а тем более вкладка лога просто перестает открываться, приходится удалять файл по ftp, наблюдая его размеры, которые легко могут достигать 400Мб