### PR TITLE
modifiy loader.php to avoid re-creating model class instances

### DIFF
--- a/upload/system/engine/loader.php
+++ b/upload/system/engine/loader.php
@@ -217,8 +217,9 @@ final class Loader {
 	}
 	
 	protected function callback($registry, $route) {
+		static $model;
 		return function($args) use($registry, $route) {
-			static $model;
+			global $model;
 			
 			$route = preg_replace('/[^a-zA-Z0-9_\/]/', '', (string)$route);
 


### PR DESCRIPTION
to avoid creating multiple model class instances the static variable 'model' should be defined outsite of the anonymous function
(otherwise every instance of the anonymous function have its own variable 'model' and finally every proxied model method is linked with its own model class instance)