### PR TITLE
Исправляем растущий лог при обновлении модификаторов.

### DIFF
--- a/upload/admin/controller/marketplace/modification.php
+++ b/upload/admin/controller/marketplace/modification.php
@@ -59,6 +59,10 @@ class ControllerMarketplaceModification extends Controller {
 		$this->load->model('setting/modification');
 
 		if ($this->validate()) {
+			// Clear log before refresh modifications
+			$handle = fopen(DIR_LOGS . 'ocmod.log', 'w+');
+			fclose($handle);
+			
 			// Just before files are deleted, if config settings say maintenance mode is off then turn it on
 			$maintenance = $this->config->get('config_maintenance');
 


### PR DESCRIPTION
При каждом обновлении модификаторов лог дописывается, что приводит к разрастанию лога и затруднению доступа к странице модификаторов в админке.
Данный лог не несёт никакой полезной информации, т.к. нужна информация только по последнему обновлению модификаторов.
Предлагаю изменение для очистки лога при каждом обновлении модификаторов.