### PR TITLE
Update db.php

### DIFF
--- a/upload/system/library/session/db.php
+++ b/upload/system/library/session/db.php
@@ -9,7 +9,10 @@ final class DB {
 
 		$this->maxlifetime = ini_get('session.gc_maxlifetime') !== null ? (int)ini_get('session.gc_maxlifetime') : 1440;
 
-		$this->gc();
+		if (date("N") == 7 && date("G") == 3)
+		{ // Clear Sessions only: Sunday, 3 AM
+			$this->db->query("DELETE FROM `" . DB_PREFIX . "session` WHERE expire < DATE_SUB(NOW(), INTERVAL 7 DAY);");
+		}
 	}
 
 	public function read($session_id) {


### PR DESCRIPTION
Уже в новой версии Opencart 3.0.3.8 отказались от очистки сессий. Это огромная нагрузка на сервер и тормоза магазина. 
Как вижу они не пришли к общему мнению как нужно очищать их. Поэтому моё предложение это запуск очистки сессий в воскресенье в 3 ночи. Пусть без нагрузки будет очистка сессий в течении часа. Это в разы лучше, чем стандартная долбёжка на каждый запрос.
Данное решение применяю на всех своих магазинах, проблем не вызывало.