### PR TITLE
Update seopro.php

### DIFF
--- a/upload/system/library/seopro.php
+++ b/upload/system/library/seopro.php
@@ -179,9 +179,9 @@ class SeoPro {
                     $blog_path = '';
                     $article_id = $data['article_id'];
 
-                    if (isset($data['blog_category_id'])) {
+                    
                         $blog_path = $this->getBlogPathByArticle($article_id);
-                    }
+                    
 
                     //start add valide get-param
                     if ($this->valide_get_param) {
@@ -640,12 +640,14 @@ class SeoPro {
         static $blog_path = [];
         $cache = 'seopro.blog_category.seopath';
 
-        if (!is_array($blog_path)) {
-            if ($this->config->get('config_seo_url_cache'))
+
+            if ($this->config->get('config_seo_url_cache')) {
                 $blog_path = $this->cache->get($cache);
-            if (!is_array($blog_path))
+            }
+            if (!is_array($blog_path)) {
                 $blog_path = [];
-        }
+            }
+
 
         if (!isset($blog_path[$blog_category_id])) {
             $max_level = 10;


### PR DESCRIPTION
1. Неправильно формировалась ссылка на запись в блоге, пропадала категория. Хотя в настройках было написано, чтобы её сохранять. Из-за этого canonnical был правильный, а адрес нет.
2. Неправильная проверка переменной для кэширования. Проверка идёт на массив ли переменная, хотя выше и так она объявляется массивом. Из-за этого кэш всегда сбрасывается
3. Немного поправлен синтаксис