### PR TITLE
Update twig.php

### DIFF
--- a/upload/system/library/template/twig.php
+++ b/upload/system/library/template/twig.php
@@ -28,11 +28,12 @@ final class Twig {
 		);
 
 		try {
-			//$loader = new \Twig\Loader\ArrayLoader(array($filename . '.twig' => $code));
+			$loader = new \Twig\Loader\ArrayLoader(array($filename . '.twig' => $code));
 
-			$loader1 = new \Twig_Loader_Array(array($filename . '.twig' => $code));
-            $loader2 = new \Twig_Loader_Filesystem(array(DIR_TEMPLATE)); // to find further includes
-            $loader = new \Twig_Loader_Chain(array($loader1, $loader2));
+			// Deprecated on PHP 8 (work on PHP 7.3.9)
+			//$loader1 = new \Twig_Loader_Array(array($filename . '.twig' => $code));
+			//$loader2 = new \Twig_Loader_Filesystem(array(DIR_TEMPLATE)); // to find further includes
+			//$loader = new \Twig_Loader_Chain(array($loader1, $loader2));
 
 			$twig = new \Twig\Environment($loader, $config);
 


### PR DESCRIPTION
На PHP 8 виникають помилки

Unknown: Using the "Twig_Loader_Array" class is deprecated since Twig version 2.7, use "Twig\Loader\ArrayLoader" instead. in .../ocstore3037glob.loc/system/storage/vendor/twig/twig/lib/Twig/Loader/Array.php on line 7

Unknown: Using the "Twig_Loader_Filesystem" class is deprecated since Twig version 2.7, use "Twig\Loader\FilesystemLoader" instead. in .../ocstore3037glob.loc/system/storage/vendor/twig/twig/lib/Twig/Loader/Filesystem.php on line 7

Unknown: Using the "Twig_Loader_Chain" class is deprecated since Twig version 2.7, use "Twig\Loader\ChainLoader" instead. in .../ocstore3037glob.loc/system/storage/vendor/twig/twig/lib/Twig/Loader/Chain.php on line 7