### PR TITLE
Update seopro.php - fix possible 404

### DIFF
--- a/upload/system/library/seopro.php
+++ b/upload/system/library/seopro.php
@@ -549,7 +549,12 @@ class SeoPro {
 
         if (isset($this->request->get['_route_'])) {
             $parts = $parts = explode('/', $this->request->get['_route_']);
-            $keyword = end($parts);
+            //$keyword = end($parts);
+            foreach ($parts as $_part) {
+                if($_part && trim($_part)){
+                    $keyword = $_part;
+                }
+            }
         } 	else {
             $keyword = '';
         }


### PR DESCRIPTION
Була така проблема:
Мова стоїть lang_1 за дефолтом і в системі є мова lang_2

Головна сторінка
site.com
site.com/lang_2 
Все працює чудово

Але якщо в системі сессій задано мову 1 і зайти по такому посиланю site.com/lang_2/
site.com/lang_2/?utm_source 
site.com/lang_2/?some_request
отримуємо 404 на головну сторінку

Хоча якщо переключаємо дефолтну мову сессій на lang_2, тоді все окей. ----
А все через те що explode робить на / $parts[1] пусто Отже система не бачить переключення мови, і не шукає в кеш мовного префіксу а одразу маємо 404.  ----

Нажаль у мене немає зараз можливості перевірити на чистому define('VERSION', '3.0.3.7') define('VERSION_BUILD', '0002');