### PR TITLE
SeoPro и GET-параметры

### DIFF
--- a/upload/.htaccess.txt
+++ b/upload/.htaccess.txt
@@ -4,7 +4,7 @@
 
 # З будь-якими питаннями підтримки звертайтесь: http://www.opencart.com
 
-Options +SymlinksIfOwnerMatch
+Options +FollowSymlinks
 
 # Запобігання перегляду вмісту директорії
 Options -Indexes

--- a/upload/.htaccess.txt
+++ b/upload/.htaccess.txt
@@ -4,7 +4,7 @@
 
 # З будь-якими питаннями підтримки звертайтесь: http://www.opencart.com
 
-Options +FollowSymlinks
+Options +SymlinksIfOwnerMatch
 
 # Запобігання перегляду вмісту директорії
 Options -Indexes

--- a/upload/admin/controller/setting/setting.php
+++ b/upload/admin/controller/setting/setting.php
@@ -1003,21 +1003,13 @@ class ControllerSettingSetting extends Controller {
 			$data['config_seopro_lowercase'] = $this->config->get('config_seopro_lowercase');
 		}
 
-		if (isset($this->request->post['config_valide_param_flag'])) {
-			$data['config_valide_param_flag'] = $this->request->post['config_valide_param_flag'];
-		} elseif ($this->config->has('config_valide_param_flag')) {
-			$data['config_valide_param_flag'] = $this->config->get('config_valide_param_flag');
-		}
-
-
 		if (isset($this->request->post['config_valide_params'])) {
 			$data['config_valide_params'] = $this->request->post['config_valide_params'];
 		} elseif ($this->config->get('config_valide_params')) {
 			$data['config_valide_params'] = $this->config->get('config_valide_params');
 		} else {
-			$data['config_valide_params'] = "block\r\nfrommarket\r\ngclid\r\nfbclid\r\nkeyword\r\nlist_type\r\nopenstat\r\nopenstat_service\r\nopenstat_campaign\r\nopenstat_ad\r\nopenstat_source\r\nposition\r\nsource\r\ntracking\r\ntype\r\nyclid\r\nymclid\r\nuri\r\nurltype\r\nutm_source\r\nutm_medium\r\nutm_campaign\r\nutm_term\r\nutm_content";
+			$data['config_valide_params'] = "block\r\nfrommarket\r\ngclid\r\nfbclid\r\nttclid\r\ngad_source\r\nsrsltid\r\nmsclkid\r\nkeyword\r\nlist_type\r\nopenstat\r\nopenstat_service\r\nopenstat_campaign\r\nopenstat_ad\r\nopenstat_source\r\nposition\r\nsource\r\ntracking\r\ntype\r\nyclid\r\nymclid\r\nuri\r\nurltype\r\nutm_source\r\nutm_medium\r\nutm_campaign\r\nutm_term\r\nutm_content\r\nutm_referrer";
 		}
-
 
 		$data['header'] = $this->load->controller('common/header');
 		$data['column_left'] = $this->load->controller('common/column_left');

--- a/upload/admin/view/template/setting/setting.twig
+++ b/upload/admin/view/template/setting/setting.twig
@@ -1368,25 +1368,6 @@
 				</div>
 			</div>
 			<div class="form-group">
-			  <label class="col-sm-2 control-label"><span data-toggle="tooltip" title="{{ help_config_valide_param_flag }}">{{ entry_config_valide_param_flag }}</span></label>
-			  <div class="col-sm-10">
-				<label class="radio-inline"> {% if config_valide_param_flag %}
-				  <input type="radio" name="config_valide_param_flag" value="1" checked="checked" />
-				  {{ text_yes }}
-				  {% else %}
-				  <input type="radio" name="config_valide_param_flag" value="1" />
-				  {{ text_yes }}
-				  {% endif %} </label>
-				<label class="radio-inline"> {% if not config_valide_param_flag %}
-				  <input type="radio" name="config_valide_param_flag" value="0" checked="checked" />
-				  {{ text_no }}
-				  {% else %}
-				  <input type="radio" name="config_valide_param_flag" value="0" />
-				  {{ text_no }}
-				  {% endif %} </label>
-			  </div>
-			</div>
-			<div class="form-group">
 			  <label class="col-sm-2 control-label" for="input-valide-params"><span data-toggle="tooltip" title="{{ help_valide_params }}">{{ entry_valide_params }}</span></label>
 			  <div class="col-sm-10">
 				<textarea name="config_valide_params" rows=10" placeholder="{{ entry_valide_params }}" id="input-valide-params" class="form-control">{{ config_valide_params }}</textarea>

--- a/upload/system/library/seopro.php
+++ b/upload/system/library/seopro.php
@@ -43,12 +43,11 @@ class SeoPro {
         $this->detectPostfix();
         $this->detectLanguage();
         $this->initHelpers();
-        if ($this->config->get('config_valide_param_flag')) {
-            $params = explode ("\r\n", $this->config->get('config_valide_params'));
-            if(!empty($params)) {
-                $this->valide_get_param = $params;
-            }
+        $params = explode ("\r\n", $this->config->get('config_valide_params'));
+        if(!empty($params)) {
+            $this->valide_get_param = $params;
         }
+        
     }
 
     public function prepareRoute($parts) {


### PR DESCRIPTION
Переключатель в настройках SeoPro включить или выключить GET-параметры не нужен, они всегда должны работать. Также актуализирован список допустимых параметров