### PR TITLE
Fix Reply-To header construction in smtp.php

### DIFF
--- a/upload/system/library/mail/smtp.php
+++ b/upload/system/library/mail/smtp.php
@@ -27,7 +27,7 @@ class Smtp extends \stdClass {
 		if (!$this->reply_to) {
 			$header .= 'Reply-To: =?UTF-8?B?' . base64_encode($this->sender) . '?= <' . $this->from . '>' . PHP_EOL;
 		} else {
-			$header .= 'Reply-To: =?UTF-8?B?' . base64_encode($this->reply_to) . '?= <' . $this->reply_to . '>' . PHP_EOL;
+			$header .= 'Reply-To: =?UTF-8?B?' . base64_encode($this->sender) . '?= <' . $this->reply_to . '>' . PHP_EOL;
 		}
 
 		$header .= 'Message-ID: <' . base_convert(str_replace(['.', ' '], '', microtime()), 10, 36) . '.' . base_convert(bin2hex(openssl_random_pseudo_bytes(8)), 16, 36) . substr($this->from, strrpos($this->from, '@')) . '>' . PHP_EOL;


### PR DESCRIPTION
Currently, OpenCart generates the header as follows:
`Reply-To: "mail@site.tld" <mail@site.tld>`
It should be:
`Reply-To: "Store name" <mail@site.tld>`

Some email clients display the address as a name.
Anti-spam filters do not like this.