### PR TITLE
Fix: безпечний парсинг XML в nbu.php та виправлення deprecated-помилки в seopro.php

### DIFF
--- a/upload/admin/controller/extension/currency/nbu.php
+++ b/upload/admin/controller/extension/currency/nbu.php
@@ -100,43 +100,50 @@ class ControllerExtensionCurrencyNbu extends Controller {
                 $currencies['UAH'] = 1.0000;
 
                 $root = $dom->documentElement;
-                $items = $root->getElementsByTagName('currency');
 
-                foreach ($items as $item)
-                {
-                    $code = $item->getElementsByTagName('cc')->item(0)->nodeValue;
-                    $curs = $item->getElementsByTagName('rate')->item(0)->nodeValue;
-                    $currencies[$code] = floatval(str_replace(',', '.', $curs));
-                }
+				if ($root) {
+					$items = $root->getElementsByTagName('currency');
 
-                if ($currencies) {
-                    $this->load->model('localisation/currency');
+					foreach ($items as $item) {
+                        $code_node = $item->getElementsByTagName('cc')->item(0);
+                        $rate_node = $item->getElementsByTagName('rate')->item(0);
 
-                    $results = $this->model_localisation_currency->getCurrencies();
-
-                    if (empty($default)) {
-                        $default = 'UAH';
-                    }
-
-                    if (!isset($currencies[$default])) {
-                        $currencies[$default] = 1.0000;
-                    }
-
-                    foreach ($results as $result) {
-                        if (isset($currencies[$result['code']])) {
-                            $from = $currencies['UAH'];
-                            $to = $currencies[$result['code']];
-
-                            $base_rate = isset($currencies[$default]) ? $currencies[$default] : 1.0000;
-
-                            $this->model_localisation_currency->editValueByCode($result['code'], ($base_rate * ($from / $to)));
+						if ($code_node && $rate_node) {
+                            $code = $code_node->nodeValue;
+                            $curs = $rate_node->nodeValue;
+                            $currencies[$code] = floatval(str_replace(',', '.', $curs));
                         }
-                    }
-                }
+					}
 
-                $this->model_localisation_currency->editValueByCode($default, '1.00000');
+					if ($currencies) {
+						$this->load->model('localisation/currency');
+	
+						$results = $this->model_localisation_currency->getCurrencies();
+	
+						if (empty($default)) {
+							$default = 'UAH';
+						}
+	
+						if (!isset($currencies[$default])) {
+							$currencies[$default] = 1.0000;
+						}
+	
+						foreach ($results as $result) {
+							if (isset($currencies[$result['code']])) {
+								$from = $currencies['UAH'];
+								$to = $currencies[$result['code']];
+	
+								$base_rate = isset($currencies[$default]) ? $currencies[$default] : 1.0000;
+	
+								$this->model_localisation_currency->editValueByCode($result['code'], ($base_rate * ($from / $to)));
+							}
+						}
 
-                $this->cache->delete('currency');
+						$this->model_localisation_currency->editValueByCode($default, '1.00000');
+
+						$this->cache->delete('currency');
+					}
+				}
             }
         }
     }

--- a/upload/system/library/seopro.php
+++ b/upload/system/library/seopro.php
@@ -601,6 +601,9 @@ class SeoPro {
 
         if ($this->config->get('config_seo_url_cache')) {
             $this->product_categories = $this->cache->get('seopro.product_categories');
+            if (!is_array($this->product_categories)) {
+                $this->product_categories = [];
+            }
             if(isset($this->product_categories[$product_id]))
                 return $this->product_categories[$product_id];
         }
@@ -609,6 +612,9 @@ class SeoPro {
         $category_id = $this->getPathByCategory($query->num_rows ? (int)$query->row['category_id'] : 0);
 
         if ($this->config->get('config_seo_url_cache')) {
+            if (!is_array($this->product_categories)) {
+                $this->product_categories = [];
+            }
             $this->product_categories[$product_id] = $category_id;
         }
 


### PR DESCRIPTION
### nbu.php
- Уникнення null dereference при некоректному XML від НБУ
- Оновлення базової валюти та очищення кешу лише при успішному парсингу
- Логіка розрахунку курсів не змінена

### seopro.php
- Виправлено deprecated-помилку PHP 8.1+: автоматичне перетворення false на масив
- $this->cache->get() повертає false коли кеш порожній — додано перевірку is_array()
- Ініціалізація $this->product_categories як порожнього масиву перед зверненням до нього